### PR TITLE
Added PortMirror service test sketch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible
-fabric-fim==1.1
+fabric-fim==1.2rc5
 fabric-cf==1.1.1
 Jinja2==2.11.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
Added a sketch of what using a PortMirror service may look like. 

For FacilityPorts - it is not a special service, it is a PTP service with a endpoint on a Facility, so it is embedded in a very similar way to the way regular PTP service is used. See Information Model Design Doc for details (p. 23). 