### PR TITLE
Storage support

### DIFF
--- a/fabric_am/__init__.py
+++ b/fabric_am/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.3b1"
+__VERSION__ = "1.3b2"

--- a/fabric_am/__init__.py
+++ b/fabric_am/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.3rc3"
+__VERSION__ = "1.3rc4"

--- a/fabric_am/__init__.py
+++ b/fabric_am/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.3rc2"
+__VERSION__ = "1.3rc3"

--- a/fabric_am/__init__.py
+++ b/fabric_am/__init__.py
@@ -1,1 +1,1 @@
-__VERSION__ = "1.3rc4"
+__VERSION__ = "1.3b1"

--- a/fabric_am/config/vm_handler_config.yml
+++ b/fabric_am/config/vm_handler_config.yml
@@ -50,7 +50,10 @@ playbooks:
   FPGA: worker_pci_provisioning.yml
   NVME: worker_pci_provisioning.yml
   Storage: head_volume_provisioning.yml
-  post_boot_config: head_vm_post_boot_config.yml
-  nw_config: nmcli_config_nw_interface.yml
+  config:
+    post_boot: head_vm_post_boot_config.yml
+    SmartNIC: nmcli_config_nw_interface.yml
+    SharedNIC: nmcli_config_nw_interface.yml
+    Storage: storage_config.yml
   cleanup:
     NVME: nvme_cleanup.yml

--- a/fabric_am/config/vm_handler_config.yml
+++ b/fabric_am/config/vm_handler_config.yml
@@ -49,6 +49,7 @@ playbooks:
   SharedNIC: worker_pci_provisioning.yml
   FPGA: worker_pci_provisioning.yml
   NVME: worker_pci_provisioning.yml
+  Storage: head_volume_provisioning.yml
   post_boot_config: head_vm_post_boot_config.yml
   nw_config: nmcli_config_nw_interface.yml
   cleanup:

--- a/fabric_am/playbooks/README.md
+++ b/fabric_am/playbooks/README.md
@@ -121,3 +121,109 @@ Returns (for successful run):
                                 "Device detached successfully"
                             ]
 ```
+
+#### Cleanup
+Cleanup procedure to be executed for the components. So far, only NVME cleanup support has been added.
+##### NVME Cleanup
+`nvme_cleanup.yml` ansible script supports cleaning up the NVME drive at the Slice deletion.
+
+Parameters required:
+- device: PCI Address of the NVME drive
+
+Example command to cleanup NVME
+```
+ansible-playbook -i inventory nvme_cleanup.yml --extra-vars 'worker_node_name=renc-w1.fabric-testbed.net device=0000:21:00.0'
+```
+
+#### Storage
+`head_volume_provisioning.yml` ansible script supports rotating storage operations. 
+##### Create a Volume
+Create a Volume for a project. This is done out of band of CF manually by the administrator. 
+
+CF requires the volume names to follow the convention:
+- Volume Name: `{project-id}-{name}`
+
+Parameters needed:
+- Project Id
+- Volume Size
+- Volume Name
+- Life time
+- Operation
+
+Example command to create a volume 
+```
+ansible-playbook head_volume_provisioning.yml -i inventory --extra-vars 'project_id=b9847fa1-13ef-49f9-9e07-ae6ad06cda3f vol_size=10 vol_name=vol1 life_time=10 vol_prov_op=create'
+```
+Created volume would like as below:
+```
+[root@renc-hn playbooks(keystone_admin)]# openstack volume show b9847fa1-13ef-49f9-9e07-ae6ad06cda3f-vol1 -f json
+{
+  "attachments": [],
+  "availability_zone": "nova",
+  "bootable": "false",
+  "consistencygroup_id": null,
+  "created_at": "2022-06-20T17:40:34.000000",
+  "description": null,
+  "encrypted": false,
+  "id": "9674170f-5cff-4336-8ada-7a2ce484420c",
+  "migration_status": null,
+  "multiattach": false,
+  "name": "b9847fa1-13ef-49f9-9e07-ae6ad06cda3f-vol1",
+  "os-vol-host-attr:host": "renc-hn.fabric-testbed.net@lvm#lvm",
+  "os-vol-mig-status-attr:migstat": null,
+  "os-vol-mig-status-attr:name_id": null,
+  "os-vol-tenant-attr:tenant_id": "3b774ebff5f845898dfcca448d9c658f",
+  "properties": {
+    "fabric_project_id": "b9847fa1-13ef-49f9-9e07-ae6ad06cda3f",
+    "expected_lifetime": "10",
+    "fabric_volume_name": "vol1"
+  },
+  "replication_status": null,
+  "size": 10,
+  "snapshot_id": null,
+  "source_volid": null,
+  "status": "available",
+  "type": "iscsi",
+  "updated_at": "2022-06-20T17:40:36.000000",
+  "user_id": "ec1f88832d8a48adb95ace6895b49bef"
+}
+```
+##### Delete a Volume
+Delete a Volume for a project. This is done out of band of CF manually by the administrator. 
+
+Parameters needed:
+- Project Id
+- Volume Name
+- Operation
+ 
+Example command to delete a volume
+```
+ansible-playbook head_volume_provisioning.yml -i inventory --extra-vars 'project_id=b9847fa1-13ef-49f9-9e07-ae6ad06cda3f vol_name=vol1 vol_prov_op=delete'
+```
+##### Attach a Volume
+Attach a Volume to the VM
+
+Parameters needed:
+- Project Id
+- VM Name
+- Volume Name
+- Operation
+
+Example command to detach a volume
+```
+ansible-playbook head_volume_provisioning.yml -i inventory --extra-vars 'project_id=b9847fa1-13ef-49f9-9e07-ae6ad06cda3f vmname=255c7e8b-2ba2-4a99-8f16-66eada8332a8-node-0 vol_name=vol1 vol_prov_op=attach'
+```
+
+##### Detach a Volume
+Attach a Volume to the VM
+
+Parameters needed:
+- Project Id
+- VM Name
+- Volume Name
+- Operation
+
+Example command to detach a volume
+```
+ansible-playbook head_volume_provisioning.yml -i inventory --extra-vars 'project_id=b9847fa1-13ef-49f9-9e07-ae6ad06cda3f vmname=255c7e8b-2ba2-4a99-8f16-66eada8332a8-node-0 vol_name=vol1 vol_prov_op=detach'
+```

--- a/fabric_am/playbooks/head_volume_provisioning.yml
+++ b/fabric_am/playbooks/head_volume_provisioning.yml
@@ -33,4 +33,4 @@
   vars:
 
   roles:
-    - head_vm_provisioning
+    - head_volume_provisioning

--- a/fabric_am/playbooks/head_volume_provisioning.yml
+++ b/fabric_am/playbooks/head_volume_provisioning.yml
@@ -1,0 +1,36 @@
+---
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+# file: head_volume_provisioning.yml
+
+- hosts:
+    - fabric_head
+
+  gather_facts: no
+
+  vars:
+
+  roles:
+    - head_vm_provisioning

--- a/fabric_am/playbooks/roles/head_volume_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/head_volume_provisioning/tasks/main.yml
@@ -36,7 +36,7 @@
       username: "{{ username }}"
     size: "{{ vol_size }}"
     display_name: "{{ project_id }}-{{ vol_name }}"
-    meta_data:
+    metadata:
       fabric_project_id: "{{ project_id }}"
       expected_lifetime: "{{ life_time }}"
       fabric_volume_name: "{{ vol_name }}"
@@ -50,7 +50,7 @@
       password: "{{ password }}"
       project_name: "{{ project_name }}"
       username: "{{ username }}"
-    display_name: "{{ vol_name }}"
+    display_name: "{{ project_id }}-{{ vol_name }}"
   when: vol_prov_op == 'delete'
 
 - name: Attach a volume
@@ -62,8 +62,7 @@
       project_name: "{{ project_name }}"
       username: "{{ username }}"
     server: "{{ vmname }}"
-    volume: "{{ volume_name }}"
-    device: "{{ device }}"
+    volume: "{{ project_id }}-{{ vol_name }}"
   when: vol_prov_op == 'attach'
 
 - name: Detach a volume
@@ -74,6 +73,6 @@
       password: "{{ password }}"
       project_name: "{{ project_name }}"
       username: "{{ username }}"
-    server: "{{ vm_name }}"
-    volume: "{{ volume_name }}"
+    server: "{{ vmname }}"
+    volume: "{{ project_id }}-{{ vol_name }}"
   when: vol_prov_op == 'detach'

--- a/fabric_am/playbooks/roles/head_volume_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/head_volume_provisioning/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+# /tasks/main.yml
+#
+
+- name: Create a volume
+  openstack.cloud.volume:
+    state: present
+    auth:
+      auth_url: "{{ auth_url }}"
+      password: "{{ password }}"
+      project_name: "{{ project_name }}"
+      username: "{{ username }}"
+    size: "{{ vol_size }}"
+    display_name: "{{ project_id }}-{{ vol_name }}"
+    meta_data:
+      fabric_project_id: "{{ project_id }}"
+      expected_lifetime: "{{ life_time }}"
+      fabric_volume_name: "{{ vol_name }}"
+  when: vol_prov_op == 'create'
+
+- name: Delete a volume
+  openstack.cloud.volume:
+    state: absent
+    auth:
+      auth_url: "{{ auth_url }}"
+      password: "{{ password }}"
+      project_name: "{{ project_name }}"
+      username: "{{ username }}"
+    display_name: "{{ vol_name }}"
+  when: vol_prov_op == 'delete'
+
+- name: Attach a volume
+  openstack.cloud.server_volume:
+    state: present
+    auth:
+      auth_url: "{{ auth_url }}"
+      password: "{{ password }}"
+      project_name: "{{ project_name }}"
+      username: "{{ username }}"
+    server: "{{ vmname }}"
+    volume: "{{ volume_name }}"
+    device: "{{ device }}"
+  when: vol_prov_op == 'attach'
+
+- name: Detach a volume
+  openstack.cloud.server_volume:
+    state: absent
+    auth:
+      auth_url: "{{ auth_url }}"
+      password: "{{ password }}"
+      project_name: "{{ project_name }}"
+      username: "{{ username }}"
+    server: "{{ vm_name }}"
+    volume: "{{ volume_name }}"
+  when: vol_prov_op == 'detach'

--- a/fabric_am/playbooks/roles/storage_config/tasks/main.yml
+++ b/fabric_am/playbooks/roles/storage_config/tasks/main.yml
@@ -26,13 +26,23 @@
 # /tasks/main.yml
 #
 
+- name: Determine the Block Device Name for the provided
+  ansible.builtin.shell:
+    cmd: lsblk "{{ device }}" -fno FSTYPE
+  register: fs_type
+  when: vol_prov_op == 'mount'
+
+- name: Set the name for the device
+  set_fact:
+    fs_type: "{{ fs_type.stdout }}"
+  when: vol_prov_op == 'mount'
+
 - name: Mount the volume
-  #ansible.builtin.shell:
-  #  'mount "{{ device }}" "/{{ vol_name }}"'
+  become: yes
   ansible.posix.mount:
     path: "/{{ vol_name }}"
     src: "{{ device }}"
-    fstype: none
-    state: present
-  when: vol_prov_op == 'mount'
+    fstype: "{{ fs_type }}"
+    state: mounted
+  when: vol_prov_op == 'mount' and fs_type is defined and fs_type != ""
 

--- a/fabric_am/playbooks/storage_config.yml
+++ b/fabric_am/playbooks/storage_config.yml
@@ -1,0 +1,36 @@
+---
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+# file: storage_config.yml
+
+- hosts:
+    - "{{ vmname }}"
+
+  gather_facts: no
+
+  vars:
+
+  roles:
+    - storage_config

--- a/fabric_am/playbooks/storage_config/tasks/main.yml
+++ b/fabric_am/playbooks/storage_config/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Komal Thareja (kthare10@renci.org)
+# /tasks/main.yml
+#
+
+- name: Mount the volume
+  #ansible.builtin.shell:
+  #  'mount "{{ device }}" "/{{ vol_name }}"'
+  ansible.posix.mount:
+    path: "/{{ vol_name }}"
+    src: "{{ device }}"
+    fstype: none
+    state: present
+  when: vol_prov_op == 'mount'
+

--- a/fabric_am/util/am_constants.py
+++ b/fabric_am/util/am_constants.py
@@ -50,7 +50,8 @@ class AmConstants:
     PROV_OP_GET = "get"
 
     VOL_PROV_OP = "vol_prov_op"
-    VOL_NAME = "volume_name"
+    VOL_NAME = "vol_name"
+    ATTACHMENTS = "attachments"
 
     SERVER = "server"
     SERVER_VM_STATE = "vm_state"

--- a/fabric_am/util/am_constants.py
+++ b/fabric_am/util/am_constants.py
@@ -37,11 +37,11 @@ class AmConstants:
 
     PLAYBOOK_SECTION = "playbooks"
     PB_LOCATION = "location"
-    PB_POST_BOOT_CONFIG = "post_boot_config"
-    PB_NW_CONFIG = "nw_config"
+    PB_POST_BOOT = "post_boot"
     PB_INVENTORY = "inventory_location"
     PB_HOSTNAME_SUFFIX = "hostname_suffix"
     PB_CLEANUP = "cleanup"
+    PB_CONFIG = "config"
 
     VM_PROV_OP = "vm_prov_op"
     PROV_OP_CREATE = "create"
@@ -52,6 +52,7 @@ class AmConstants:
     VOL_PROV_OP = "vol_prov_op"
     VOL_NAME = "vol_name"
     ATTACHMENTS = "attachments"
+    PROV_OP_MOUNT = "mount"
 
     SERVER = "server"
     SERVER_VM_STATE = "vm_state"

--- a/fabric_am/util/am_constants.py
+++ b/fabric_am/util/am_constants.py
@@ -44,10 +44,13 @@ class AmConstants:
     PB_CLEANUP = "cleanup"
 
     VM_PROV_OP = "vm_prov_op"
-    VM_PROV_OP_CREATE = "create"
-    VM_PROV_OP_DELETE = "delete"
+    PROV_OP_CREATE = "create"
+    PROV_OP_DELETE = "delete"
     VM_PROV_OP_ATTACH_FIP = "attach_fip"
-    VM_PROV_OP_GET = "get"
+    PROV_OP_GET = "get"
+
+    VOL_PROV_OP = "vol_prov_op"
+    VOL_NAME = "volume_name"
 
     SERVER = "server"
     SERVER_VM_STATE = "vm_state"
@@ -69,9 +72,9 @@ class AmConstants:
     PCI_SLOT = "slot"
     PCI_FUNCTION = "function"
     PCI_OPERATION = "pci_prov_op"
-    PCI_PROV_ATTACH = "attach"
-    PCI_PROV_DETACH = "detach"
-    PCI_PROV_DEVICE = "device"
+    PROV_ATTACH = "attach"
+    PROV_DETACH = "detach"
+    PROV_DEVICE = "device"
     WORKER_NODE_NAME = "worker_node_name"
 
     ANSIBLE_FACTS = "ansible_facts"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ansible
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 paramiko
-fabric-cf==1.2.2
+fabric-cf==1.3rc1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ansible
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 paramiko
-fabric-cf==1.3rc1
+fabric-cf==1.3b1


### PR DESCRIPTION
https://github.com/fabric-testbed/AMHandlers/issues/49

**Assumptions:**
- Volumes are created outside CF but follow the naming convention such as `{project_id}-{name}`
- Volumes are deleted outside CF

**Changes made:**
- Added `head_volume_provisioning.yml` ansible which supports create, delete, attach and detach operations
- Updated readme to reflect usage of the ansible script
- Updated VM handler to attach/detach storage when requested
- Added `storage_config.yml` for mounting the volume inside the VM to a mountpoint `/<volume_name>` provided the volume has filesystem configured on it

**Example Slice:**
```
from fabrictestbed.slice_editor import ExperimentTopology, Capacities, ComponentType, ComponentModelType, ServiceType, Labels
# Create topology
t = ExperimentTopology()

# Set capacities
cap = Capacities(core=2, ram=6, disk=10)

sites = ['RENC']
labels = Labels()
labels.instance_parent = 'renc-w1.fabric-testbed.net'
name="node"
i=0
for s in sites:
    # Add node
    nm = f"{name}-{i}"
    
    n = t.add_node(name=f"{name}-{i}", site=s)

    # Set properties
    n.set_properties(capacities=cap, image_type='qcow2', image_ref='default_rocky_8', labels=labels)
    n.add_component(model_type=ComponentModelType.SharedNIC_ConnectX_6, name=f"{name}-{i}-nic1")
    n.add_storage(name="vol1", labels=Labels(local_name='vol1'))
    n.add_storage(name="vol2", labels=Labels(local_name='vol2'))
    i += 1

# Generate Slice Graph
slice_graph = t.serialize()
```

**Volumes inside the VM post creation:**
NOTE: Volume for which the filesystem can be determined is mounted at the path `/<volume_name>` only if flags.auto_mount=True.
Ownership installing a filesystem on the volume is on the user.
In the example below, filesystem was configured on the volume `/dev/vdb` so it was mounted. `/dev/vdc` was not mounted as it did not have any filesystem on it.

```
[rocky@860026d9-eb8a-4b62-931e-1fe455defabd-node-0 ~]$ lsblk
NAME   MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
vda    252:0    0  10G  0 disk
└─vda1 252:1    0  10G  0 part /
vdb    252:16   0  10G  0 disk /vol1
vdc    252:32   0  10G  0 disk
```

**Volumes on openstack look like below:**
```
[root@renc-hn playbooks(keystone_admin)]# openstack volume list
+--------------------------------------+-------------------------------------------+-----------+------+----------------------------------------------------------------------+
| ID                                   | Name                                      | Status    | Size | Attached to                                                          |
+--------------------------------------+-------------------------------------------+-----------+------+----------------------------------------------------------------------+
| d77bea3c-df28-479d-a7f8-50f6ab0053e7 | b9847fa1-13ef-49f9-9e07-ae6ad06cda3f-vol2 | in-use    |   10 | Attached to 860026d9-eb8a-4b62-931e-1fe455defabd-node-0 on /dev/vdc  |
| 9674170f-5cff-4336-8ada-7a2ce484420c | b9847fa1-13ef-49f9-9e07-ae6ad06cda3f-vol1 | in-use    |   10 | Attached to 860026d9-eb8a-4b62-931e-1fe455defabd-node-0 on /dev/vdb  |
```

**Openstack Volume Snapshot**
```
[root@renc-hn playbooks(keystone_admin)]# openstack volume show b9847fa1-13ef-49f9-9e07-ae6ad06cda3f-vol1 -f json
{
  "attachments": [],
  "availability_zone": "nova",
  "bootable": "false",
  "consistencygroup_id": null,
  "created_at": "2022-06-20T17:40:34.000000",
  "description": null,
  "encrypted": false,
  "id": "9674170f-5cff-4336-8ada-7a2ce484420c",
  "migration_status": null,
  "multiattach": false,
  "name": "b9847fa1-13ef-49f9-9e07-ae6ad06cda3f-vol1",
  "os-vol-host-attr:host": "renc-hn.fabric-testbed.net@lvm#lvm",
  "os-vol-mig-status-attr:migstat": null,
  "os-vol-mig-status-attr:name_id": null,
  "os-vol-tenant-attr:tenant_id": "3b774ebff5f845898dfcca448d9c658f",
  "properties": {
    "fabric_project_id": "b9847fa1-13ef-49f9-9e07-ae6ad06cda3f",
    "expected_lifetime": "10",
    "fabric_volume_name": "vol1"
  },
  "replication_status": null,
  "size": 10,
  "snapshot_id": null,
  "source_volid": null,
  "status": "available",
  "type": "iscsi",
  "updated_at": "2022-06-20T23:23:45.000000",
  "user_id": "ec1f88832d8a48adb95ace6895b49bef"
}
```