### PR TITLE
Initial version of FPGA attach/detach handler

### DIFF
--- a/fabric_am/playbooks/README.md
+++ b/fabric_am/playbooks/README.md
@@ -124,12 +124,12 @@ Returns (for successful run):
 
 #### Attach/Detach FPGA
 ```bash
-ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00'
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00 fpga_usb_vendor_id=0x0403 fpga_usb_product_id=0x6011'
 ```
 
 To detach:
 ```commandline
-ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=detach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00'
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=detach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00 fpga_usb_vendor_id=0x0403 fpga_usb_product_id=0x6011'
 ```
 Note that this rewrites the domain file, does not do hotplug. It attaches however many PCI functions belong to the device
 into the VM. To make this change take effect reboot via `openstack server reboot` (note that rebooting via
@@ -137,6 +137,10 @@ virsh doesn't work - the changes do not take effect).
 
 Note also that the reboot detaches all hotplugs (and unmounts the volumes).
 
+For testing you can skip `bus`, `slot`, and vendor and product id parameters as sane defaults are present in the role file.
+```commandline
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net'
+```
 #### Cleanup
 Cleanup procedure to be executed for the components. So far, only NVME cleanup support has been added.
 ##### NVME Cleanup

--- a/fabric_am/playbooks/README.md
+++ b/fabric_am/playbooks/README.md
@@ -124,12 +124,12 @@ Returns (for successful run):
 
 #### Attach/Detach FPGA
 ```bash
-ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00 fpga_usb_vendor_id=0x0403 fpga_usb_product_id=0x6011'
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00 fpga_usb_vendor_id=0x0403 fpga_usb_product_id=0x6011'
 ```
 
 To detach:
 ```bash
-ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=detach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00 fpga_usb_vendor_id=0x0403 fpga_usb_product_id=0x6011'
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=detach kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00 fpga_usb_vendor_id=0x0403 fpga_usb_product_id=0x6011'
 ```
 Note that this rewrites the domain file, does not do hotplug. It attaches however many PCI functions belong to the device
 into the VM. To make this change take effect reboot via `openstack server reboot` (note that rebooting via
@@ -139,7 +139,7 @@ Note also that the reboot detaches all hotplugs (and unmounts the volumes).
 
 For testing you can skip `bus`, `slot`, and vendor and product id parameters as sane defaults are present in the role file.
 ```bash
-ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net'
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net'
 ```
 #### Cleanup
 Cleanup procedure to be executed for the components. So far, only NVME cleanup support has been added.

--- a/fabric_am/playbooks/README.md
+++ b/fabric_am/playbooks/README.md
@@ -122,6 +122,21 @@ Returns (for successful run):
                             ]
 ```
 
+#### Attach/Detach FPGA
+```bash
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00'
+```
+
+To detach:
+```commandline
+ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=detach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00'
+```
+Note that this rewrites the domain file, does not do hotplug. It attaches however many PCI functions belong to the device
+into the VM. To make this change take effect reboot via `openstack server reboot` (note that rebooting via
+virsh doesn't work - the changes do not take effect).
+
+Note also that the reboot detaches all hotplugs (and unmounts the volumes).
+
 #### Cleanup
 Cleanup procedure to be executed for the components. So far, only NVME cleanup support has been added.
 ##### NVME Cleanup

--- a/fabric_am/playbooks/README.md
+++ b/fabric_am/playbooks/README.md
@@ -128,7 +128,7 @@ ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=at
 ```
 
 To detach:
-```commandline
+```bash
 ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=detach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net bus=0x25 slot=0x00 fpga_usb_vendor_id=0x0403 fpga_usb_product_id=0x6011'
 ```
 Note that this rewrites the domain file, does not do hotplug. It attaches however many PCI functions belong to the device
@@ -138,7 +138,7 @@ virsh doesn't work - the changes do not take effect).
 Note also that the reboot detaches all hotplugs (and unmounts the volumes).
 
 For testing you can skip `bus`, `slot`, and vendor and product id parameters as sane defaults are present in the role file.
-```commandline
+```bash
 ansible-playbook -i inventory fpga_provisioning.yml --extra-vars 'pci_prov_op=attach_fpga kvmguest_name=instance-000011d4 worker_node_name=renc-w2.fabric-testbed.net'
 ```
 #### Cleanup

--- a/fabric_am/playbooks/fpga_provisioning.yml
+++ b/fabric_am/playbooks/fpga_provisioning.yml
@@ -13,7 +13,7 @@
     # best to set this high and not worry about collisions
     # must be lower case to match removal
     dest_slot: "0x1a"
-    num_pci_functions: 2
+    num_pci_functions: 1
     usb_ctrlr_idx: 2
     # default U280 info
     fpga_usb_vendor_id: "0x0403"

--- a/fabric_am/playbooks/fpga_provisioning.yml
+++ b/fabric_am/playbooks/fpga_provisioning.yml
@@ -5,13 +5,17 @@
     - "{{ worker_node_name }}"
 
   vars:
+    # note that virsh rewrites these values so
+    # for removal to work these must appear exactly so
+    # you can't, for example say slot: "0x0"
+    # insertion will work but the value in domain xml will be "0x00"
     domain: "0x0000"
     bus: "0x25"
-    slot: "0x0"
+    slot: "0x00"
     dest_domain: "0x0000"
     dest_bus: "0x00"
-    # best to set this high and not worry about collisions
-    # must be lower case to match removal
+    # best to set dest_slot high and not worry about collisions
+    # must be lower case to match removal. must be less than 0x1f
     dest_slot: "0x1a"
     num_pci_functions: 1
     usb_ctrlr_idx: 2

--- a/fabric_am/playbooks/fpga_provisioning.yml
+++ b/fabric_am/playbooks/fpga_provisioning.yml
@@ -1,0 +1,25 @@
+---
+# file: fpga_provisioning.yml
+
+- hosts:
+    - "{{ worker_node_name }}"
+
+  vars:
+    domain: "0x0000"
+    bus: "0x25"
+    slot: "0x0"
+    dest_domain: "0x0000"
+    dest_bus: "0x00"
+    # best to set this high and not worry about collisions
+    # must be lower case to match removal
+    dest_slot: "0x1a"
+    num_pci_functions: 2
+    usb_ctrlr_idx: 2
+    # default U280 info
+    fpga_usb_vendor_id: "0x0403"
+    fpga_usb_product_id: "0x6011"
+    fpga_dest_usb_bus: "2"
+    fpga_dest_usb_port: "2"
+
+  roles:
+    - fpga_provisioning

--- a/fabric_am/playbooks/fpga_provisioning.yml
+++ b/fabric_am/playbooks/fpga_provisioning.yml
@@ -15,8 +15,8 @@
     dest_domain: "0x0000"
     dest_bus: "0x00"
     # best to set dest_slot high and not worry about collisions
-    # must be lower case to match removal. must be less than 0x1f
-    dest_slot: "0x1a"
+    # must be lower case to match removal. must no larger than 0x1f
+    dest_slot: "0x1f"
     num_pci_functions: 1
     usb_ctrlr_idx: 2
     # default U280 info

--- a/fabric_am/playbooks/fpga_provisioning.yml
+++ b/fabric_am/playbooks/fpga_provisioning.yml
@@ -17,7 +17,6 @@
     # best to set dest_slot high and not worry about collisions
     # must be lower case to match removal. must no larger than 0x1f
     dest_slot: "0x1f"
-    num_pci_functions: 1
     usb_ctrlr_idx: 2
     # default U280 info
     fpga_usb_vendor_id: "0x0403"

--- a/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
@@ -3,6 +3,16 @@
   command: virsh dumpxml --inactive --security-info {{ kvmguest_name }}
   register: dumpxml_output
 
+- name: Count the number of PCI functions of the device
+  shell: "lspci | grep Xilinx | grep {{ bus[2:] }} | wc -l"
+  register: num_pci_functions_output
+  when: pci_prov_op == 'attach_fpga'
+
+- name: Save integer value as a fact
+  set_fact:
+    num_pci: "{{ num_pci_functions_output.stdout | int }}"
+  when: pci_prov_op == 'attach_fpga'
+
 - name: Save XML to file
   copy:
     content: "{{ dumpxml_output.stdout }}"
@@ -20,7 +30,7 @@
             </source>
             <address type='pci' domain='{{ dest_domain }}' bus='{{ dest_bus }}' slot='{{ dest_slot }}' function='0x0' multifunction='on'/>
           </hostdev>
-          {% for pci_func in range(1, num_pci_functions) %}
+          {% for pci_func in range(1, (num_pci | int)) %}
           <hostdev mode='subsystem' type='pci' managed='yes'>
             <source>
               <address domain='{{ domain }}' bus='{{ bus }}' slot='{{ slot }}' function='0x0{{ pci_func }}'/>

--- a/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
@@ -9,6 +9,9 @@
     dest: /tmp/{{ kvmguest_name }}.xml
 
 - name: Generate new PCI devices XML sections
+  # adds primary device (function 0x00) and a specified
+  # number of other functions. Also adds an XHCI USB3.0 controller
+  # and plugs USB JTAG into it
   set_fact:
     pci_devices_xml: |
           <hostdev mode='subsystem' type='pci' managed='yes'>
@@ -25,7 +28,7 @@
             <address type='pci' domain='{{ dest_domain }}' bus='{{ dest_bus }}' slot='{{ dest_slot }}' function='0x0{{ pci_func }}'/>
           </hostdev>
           {% endfor %}
-          <controller type='usb' index='2' model='nec-xhci'/>
+          <controller type='usb' index='{{ fpga_dest_usb_bus }}' model='nec-xhci'/>
           <hostdev mode='subsystem' type='usb' managed='yes'>
             <source>
               <vendor id='{{ fpga_usb_vendor_id }}'/>
@@ -45,22 +48,22 @@
   when: pci_prov_op == 'attach_fpga'
 
 - name: Remove FPGA configuration from domain XML file
-  # no choice but to use the XML module
+  # notice this removes all PCI functions because they all
+  # have the same bus and slot
   xml:
     path: "/tmp/{{ kvmguest_name }}.xml"
     xpath: /domain/devices/hostdev[source[address[@bus='{{ bus }}' and @slot='{{ slot }}']]]
     state: absent
   when: pci_prov_op == 'detach_fpga'
 
-- name: Remove USB device
-  # dangerous because only looks at vendor id
+- name: Remove USB JTAG device
   xml:
     path: "/tmp/{{ kvmguest_name }}.xml"
-    xpath: /domain/devices/hostdev[source[vendor[@id='{{ fpga_usb_vendor_id }}']]]
+    xpath: /domain/devices/hostdev[source[vendor[@id='{{ fpga_usb_vendor_id }}'] and product[@id='{{ fpga_usb_product_id }}']]]
     state: absent
   when: pci_prov_op == 'detach_fpga'
 
-- name: Remove USB controller
+- name: Remove USB3.0 XHCI controller
   xml:
     path: "/tmp/{{ kvmguest_name }}.xml"
     xpath: /domain/devices/controller[@model='nec-xhci']

--- a/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
@@ -48,7 +48,7 @@
   # no choice but to use the XML module
   xml:
     path: "/tmp/{{ kvmguest_name }}.xml"
-    xpath: /domain/devices/hostdev[address[@domain='{{ dest_domain }}' and @bus='{{ dest_bus }}' and @slot='{{ dest_slot }}']]
+    xpath: /domain/devices/hostdev[source[address[@bus='{{ bus }}' and @slot='{{ slot }}']]]
     state: absent
   when: pci_prov_op == 'detach_fpga'
 

--- a/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+- name: Dump domain XML to file
+  command: virsh dumpxml --inactive --security-info {{ kvmguest_name }}
+  register: dumpxml_output
+
+- name: Save XML to file
+  copy:
+    content: "{{ dumpxml_output.stdout }}"
+    dest: /tmp/{{ kvmguest_name }}.xml
+
+- name: Generate new PCI devices XML sections
+  set_fact:
+    pci_devices_xml: |
+          <hostdev mode='subsystem' type='pci' managed='yes'>
+            <source>
+              <address domain='{{ domain }}' bus='{{ bus }}' slot='{{ slot }}' function='0x0'/>
+            </source>
+            <address type='pci' domain='{{ dest_domain }}' bus='{{ dest_bus }}' slot='{{ dest_slot }}' function='0x0' multifunction='on'/>
+          </hostdev>
+          {% for pci_func in range(1, num_pci_functions) %}
+          <hostdev mode='subsystem' type='pci' managed='yes'>
+            <source>
+              <address domain='{{ domain }}' bus='{{ bus }}' slot='{{ slot }}' function='0x0{{ pci_func }}'/>
+            </source>
+            <address type='pci' domain='{{ dest_domain }}' bus='{{ dest_bus }}' slot='{{ dest_slot }}' function='0x0{{ pci_func }}'/>
+          </hostdev>
+          {% endfor %}
+          <controller type='usb' index='2' model='nec-xhci'/>
+          <hostdev mode='subsystem' type='usb' managed='yes'>
+            <source>
+              <vendor id='{{ fpga_usb_vendor_id }}'/>
+              <product id='{{ fpga_usb_product_id }}'/>
+            </source>
+            <address type='usb' bus='{{ fpga_dest_usb_bus }}' port='{{ fpga_dest_usb_port }}'/>
+          </hostdev>
+  when: pci_prov_op == 'attach_fpga'
+
+- name: Update the domain XML
+  # unfortunately XML module is very limited in functionality
+  blockinfile:
+    path: "/tmp/{{ kvmguest_name }}.xml"
+    insertafter: "^  <devices>"
+    marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
+    block: "{{ pci_devices_xml }}"
+  when: pci_prov_op == 'attach_fpga'
+
+- name: Remove FPGA configuration from domain XML file
+  # no choice but to use the XML module
+  xml:
+    path: "/tmp/{{ kvmguest_name }}.xml"
+    xpath: /domain/devices/hostdev[address[@domain='{{ dest_domain }}' and @bus='{{ dest_bus }}' and @slot='{{ dest_slot }}']]
+    state: absent
+  when: pci_prov_op == 'detach_fpga'
+
+- name: Remove USB device
+  # dangerous because only looks at vendor id
+  xml:
+    path: "/tmp/{{ kvmguest_name }}.xml"
+    xpath: /domain/devices/hostdev[source[vendor[@id='{{ fpga_usb_vendor_id }}']]]
+    state: absent
+  when: pci_prov_op == 'detach_fpga'
+
+- name: Remove USB controller
+  xml:
+    path: "/tmp/{{ kvmguest_name }}.xml"
+    xpath: /domain/devices/controller[@model='nec-xhci']
+    state: absent
+  when: pci_prov_op == 'detach_fpga'
+
+- name: Define edited domain
+  shell: virsh define /tmp/{{ kvmguest_name }}.xml
+  register: define_output
+
+- name: Delete XML file
+  file:
+    path: /tmp/{{ kvmguest_name }}.xml
+    state: absent

--- a/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
@@ -6,12 +6,12 @@
 - name: Count the number of PCI functions of the device
   shell: "lspci | grep Xilinx | grep {{ bus[2:] }} | wc -l"
   register: num_pci_functions_output
-  when: pci_prov_op == 'attach_fpga'
+  when: pci_prov_op == 'attach'
 
 - name: Save integer value as a fact
   set_fact:
     num_pci: "{{ num_pci_functions_output.stdout | int }}"
-  when: pci_prov_op == 'attach_fpga'
+  when: pci_prov_op == 'attach'
 
 - name: Save XML to file
   copy:
@@ -24,7 +24,7 @@
     xpath: /domain/devices/hostdev[source[address[@bus='{{ bus }}' and @slot='{{ slot }}']]]
     count: yes
   register: device_xml_matches
-  when: pci_prov_op == 'attach_fpga'
+  when: pci_prov_op == 'attach'
 
 - name: Generate new PCI devices XML sections
   # adds primary device (function 0x00) and a specified
@@ -54,7 +54,7 @@
             </source>
             <address type='usb' bus='{{ fpga_dest_usb_bus }}' port='{{ fpga_dest_usb_port }}'/>
           </hostdev>
-  when: pci_prov_op == 'attach_fpga' and device_xml_matches.count == 0
+  when: pci_prov_op == 'attach' and device_xml_matches.count == 0
 
 - name: Update the domain XML
   blockinfile:
@@ -62,7 +62,7 @@
     insertafter: "^  <devices>"
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     block: "{{ pci_devices_xml }}"
-  when: pci_prov_op == 'attach_fpga' and device_xml_matches.count == 0
+  when: pci_prov_op == 'attach' and device_xml_matches.count == 0
 
 - name: Remove FPGA configuration from domain XML file
   # notice this removes all PCI functions because they all
@@ -71,21 +71,21 @@
     path: "/tmp/{{ kvmguest_name }}.xml"
     xpath: /domain/devices/hostdev[source[address[@bus='{{ bus }}' and @slot='{{ slot }}']]]
     state: absent
-  when: pci_prov_op == 'detach_fpga'
+  when: pci_prov_op == 'detach'
 
 - name: Remove USB JTAG device
   xml:
     path: "/tmp/{{ kvmguest_name }}.xml"
     xpath: /domain/devices/hostdev[source[vendor[@id='{{ fpga_usb_vendor_id }}'] and product[@id='{{ fpga_usb_product_id }}']]]
     state: absent
-  when: pci_prov_op == 'detach_fpga'
+  when: pci_prov_op == 'detach'
 
 - name: Remove USB3.0 XHCI controller
   xml:
     path: "/tmp/{{ kvmguest_name }}.xml"
     xpath: /domain/devices/controller[@model='nec-xhci']
     state: absent
-  when: pci_prov_op == 'detach_fpga'
+  when: pci_prov_op == 'detach'
 
 - name: Define edited domain
   shell: virsh define /tmp/{{ kvmguest_name }}.xml

--- a/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
+++ b/fabric_am/playbooks/roles/fpga_provisioning/tasks/main.yml
@@ -18,6 +18,14 @@
     content: "{{ dumpxml_output.stdout }}"
     dest: /tmp/{{ kvmguest_name }}.xml
 
+- name: Check that on attach the device isn't already attached
+  xml:
+    path: /tmp/{{ kvmguest_name }}.xml
+    xpath: /domain/devices/hostdev[source[address[@bus='{{ bus }}' and @slot='{{ slot }}']]]
+    count: yes
+  register: device_xml_matches
+  when: pci_prov_op == 'attach_fpga'
+
 - name: Generate new PCI devices XML sections
   # adds primary device (function 0x00) and a specified
   # number of other functions. Also adds an XHCI USB3.0 controller
@@ -46,16 +54,15 @@
             </source>
             <address type='usb' bus='{{ fpga_dest_usb_bus }}' port='{{ fpga_dest_usb_port }}'/>
           </hostdev>
-  when: pci_prov_op == 'attach_fpga'
+  when: pci_prov_op == 'attach_fpga' and device_xml_matches.count == 0
 
 - name: Update the domain XML
-  # unfortunately XML module is very limited in functionality
   blockinfile:
     path: "/tmp/{{ kvmguest_name }}.xml"
     insertafter: "^  <devices>"
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     block: "{{ pci_devices_xml }}"
-  when: pci_prov_op == 'attach_fpga'
+  when: pci_prov_op == 'attach_fpga' and device_xml_matches.count == 0
 
 - name: Remove FPGA configuration from domain XML file
   # notice this removes all PCI functions because they all


### PR DESCRIPTION
@kthare10 don't approve just yet (not sure if I'm merging to the right branch for one thing, for another read-on).

This is the initial version that does 'the right thing' in attaching a single FPGA. It uses a bunch of variables, most of which have sane defaults:
```
    domain: "0x0000"
    bus: "0x25"
    slot: "0x0"
    dest_domain: "0x0000"
    dest_bus: "0x00"
    # best to set this high and not worry about collisions
    # must be lower case to match removal
    dest_slot: "0x1a"
    usb_ctrlr_idx: 2
    # default U280 info
    fpga_usb_vendor_id: "0x0403"
    fpga_usb_product_id: "0x6011"
    fpga_dest_usb_bus: "2"
    fpga_dest_usb_port: "2"
```
It modifies the domain XML definition (but does not reboot the VM). It defines two workflows: `attach_fpga` and `detach_fpga`. 

The attach attaches the main device and any number of its subfunctions (so specify `num_pci_functions` as 1 if only main device is needed). It also attaches an XHCI controller needed to support the FPGA and its USB JTAG port. 

Some caveats:

1. In my experience `virsh reboot` on the worker does not achieve the needed result - you need to do `openstack server reboot` on the head node after running either workflow to make it take effect
2. The reboot appears to preserve hot-plugged devices.
3. The tasks are cobbled together using `blockinfile` ansible module to insert the lines and `xml` ansible module to remove them. The XML module is fairly weak in capabilities, especially the version we are using. 
    - the attachment 'guesses' at the right slot to use - it is set high enough (`1f`, which is the maximum possible) not to collide with any other device. The alternative is to scan the domain file looking for open slots (which we may need to do). But as I mentioned, the XML module is not very capable. 
    - not clear this will work with multiple FPGAs without errors, but unable to test.
