### PR TITLE
directly use the components from diff

### DIFF
--- a/fabric_am/handlers/vm_handler.py
+++ b/fabric_am/handlers/vm_handler.py
@@ -309,28 +309,26 @@ class VMHandler(HandlerBase):
             if diff is not None:
                 # Modify topology
                 for x in diff.added.components:
-                    component = modified_sliver.attached_components_info.devices[x]
                     user = self.__get_default_user(image=current_sliver.get_image_ref())
                     self.__attach_detach_pci(playbook_path=playbook_path, inventory_path=inventory_path,
                                              host=current_sliver.label_allocations.instance_parent,
                                              instance_name=current_sliver.label_allocations.instance,
                                              device_name=str(unit.get_reservation_id()),
-                                             component=component, vm_name=current_sliver.get_name(),
+                                             component=x, vm_name=current_sliver.get_name(),
                                              project_id=project_id, mgmt_ip=current_sliver.get_management_ip(),
                                              user=user)
 
                     user = self.__get_default_user(image=current_sliver.get_image_ref())
-                    self.__configure_component(component=component,
+                    self.__configure_component(component=x,
                                                mgmt_ip=current_sliver.management_ip,
                                                user=user)
 
                 for x in diff.removed.components:
-                    component = modified_sliver.attached_components_info.devices[x]
                     self.__attach_detach_pci(playbook_path=playbook_path, inventory_path=inventory_path,
                                              host=current_sliver.label_allocations.instance_parent,
                                              instance_name=current_sliver.label_allocations.instance,
                                              device_name=str(unit.get_reservation_id()),
-                                             component=component, vm_name=current_sliver.get_name(),
+                                             component=x, vm_name=current_sliver.get_name(),
                                              project_id=project_id, attach=False)
             else:
                 # Modify configuration


### PR DESCRIPTION
#118 - Modify add/remove component fails

Modify fails to add components; With the recent changes in sliver.diff()

diff.added.components now returns ComponentSliver whereas it used to just return component names. This has caused modify AM handler to stop working.

Root cause:
In this code, x is expected to be a name
```
                for x in diff.added.components:
                    component = modified_sliver.attached_components_info.devices[x]
```