### PR TITLE
Add timeouts to NSO clean_restart HTTP calls

### DIFF
--- a/fabric_am/handlers/net_handler.py
+++ b/fabric_am/handlers/net_handler.py
@@ -109,7 +109,8 @@ class NetHandler(HandlerBase):
 
         # -X DELETE all ncs:services
         try:
-            res = requests.delete(url, headers=hdrs, auth=(user, pw), verify=False)
+            # (connect, read) timeout so a hung NSO cannot block actor startup indefinitely
+            res = requests.delete(url, headers=hdrs, auth=(user, pw), verify=False, timeout=(5, 60))
         except Exception as e:
             self.get_logger().error(f"Failure to clean up NSO services: {e}")
 
@@ -121,7 +122,8 @@ class NetHandler(HandlerBase):
             }
         }
         try:
-            res = requests.post(url + '/logging', headers=hdrs, data=json.dumps(logger_data), auth=(user, pw), verify=False)
+            res = requests.post(url + '/logging', headers=hdrs, data=json.dumps(logger_data), auth=(user, pw),
+                                verify=False, timeout=(5, 60))
         except Exception as e:
             self.get_logger().error(f"Failure to clean up NSO services: {e}")
 


### PR DESCRIPTION
## Summary

The NSO `DELETE`/`POST` calls in `NetHandler.clean_restart` had **no request timeout**, so a hung NSO endpoint could block actor startup indefinitely.

## Changes

- **`fabric_am/handlers/net_handler.py`**: add a `(connect, read)` timeout of `(5, 60)` to both the `requests.delete` and `requests.post` calls in `clean_restart`.

## Verification

- `python -m compileall` passes.

Targets `rel-2.0.1` (theme 4 of the improvement sweep).

Note (out of scope here, tracked separately): these calls still use `verify=False` and do not check `res.status_code`; hardening TLS verification and response-status handling is a follow-up.
