### PR TITLE
Fix Issue #161 retry loop off-by-one error in delete

### DIFF
--- a/fabric_am/handlers/net_handler.py
+++ b/fabric_am/handlers/net_handler.py
@@ -250,7 +250,7 @@ class NetHandler(HandlerBase):
                     self.__cleanup(sliver=sliver, raise_exception=True, unit_id=unit_id)
                     break
                 except (PlaybookException, NetHandlerException) as pne:
-                    if i < delete_retries:
+                    if i < delete_retries - 1:
                         continue
                     else:
                         self.get_logger().warning(f'Delete Failed - cleanup attempts {delete_retries}')

--- a/fabric_am/handlers/vm_handler.py
+++ b/fabric_am/handlers/vm_handler.py
@@ -705,7 +705,7 @@ class VMHandler(HandlerBase):
                 time.sleep(5)
                 break
             except Exception as e:
-                if i < delete_retries:
+                if i < delete_retries - 1:
                     continue
                 else:
                     self.get_logger().warning(f'Delete Failed - cleanup attempts {delete_retries}')
@@ -729,7 +729,7 @@ class VMHandler(HandlerBase):
                 time.sleep(5)
                 break
             except Exception as e:
-                if i < delete_retries:
+                if i < delete_retries - 1:
                     continue
                 else:
                     self.get_logger().warning(f'Delete Failed - cleanup attempts {delete_retries}')


### PR DESCRIPTION
Fixes Issue: #161 

Corrects off-by-one in retry loop guards that causes failed cleanup attempts to be silently treated as success. Applies to net_handler and vm_handler delete paths.